### PR TITLE
Fix letter case problem in references to bower_components for proj4"L…

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,8 +5,8 @@
     <title>MapML Leaflet client</title>
     <link rel="stylesheet" href="bower_components/mapml-leaflet/leaflet.css" />
     <script src="bower_components/mapml-leaflet/leaflet-src.js"></script>
-    <script src="bower_components/proj4leaflet/lib/proj4-compressed.js"></script> 
-    <script src="bower_components/proj4leaflet/src/proj4leaflet.js"></script>
+    <script src="bower_components/proj4Leaflet/lib/proj4-compressed.js"></script> 
+    <script src="bower_components/proj4Leaflet/src/proj4leaflet.js"></script>
     <script src="src/mapml.js"></script>
     <script src="src/URI.js"></script>
     <script src="bower_components/webcomponentsjs/webcomponents-lite.min.js"></script>


### PR DESCRIPTION
…"eaflet,

vs the actual name of the js file proj4leaflet.js.  C'mon, people!